### PR TITLE
fix(npm): update google-photos-album-image-url-fetch

### DIFF
--- a/lib/faceboxSeed.js
+++ b/lib/faceboxSeed.js
@@ -6,7 +6,7 @@ const rp = require('request-promise-native');
 const chalk = require('chalk');
 const download = require('image-downloader');
 const {
-    GooglePhotos
+    fetchImageUrls
 } = require('google-photos-album-image-url-fetch');
 
 /**
@@ -17,7 +17,7 @@ const {
  */
 const train = async (name, album, facebox) => {
     // Get a list of URLS for each Image in a Public Google Photos Album
-    const re = await GooglePhotos.Album.fetchImageUrls(album);
+    const re = await fetchImageUrls(album);
 
     // Build a collection of request promises for each image, to be send to the teach route
     const requests = re.map(x => rp({

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,11 @@
       }
     },
     "agent-base": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+      "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
       "requires": {
-        "es6-promisify": "^5.0.0"
+        "debug": "4"
       }
     },
     "ajv": {
@@ -125,9 +125,9 @@
       }
     },
     "debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
         "ms": "^2.1.1"
       }
@@ -144,19 +144,6 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
-      }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "requires": {
-        "es6-promise": "^4.0.3"
       }
     },
     "escape-string-regexp": {
@@ -205,13 +192,14 @@
       }
     },
     "gaxios": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.0.1.tgz",
-      "integrity": "sha512-c1NXovTxkgRJTIgB2FrFmOFg4YIV6N/bAa4f/FZ4jIw13Ql9ya/82x69CswvotJhbV3DiGnlTZwoq2NVXk2Irg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.0.3.tgz",
+      "integrity": "sha512-PkzQludeIFhd535/yucALT/Wxyj/y2zLyrMwPcJmnLHDugmV49NvAi/vb+VUq/eWztATZCNcb8ue+ywPG+oLuw==",
       "requires": {
         "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
-        "https-proxy-agent": "^2.2.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
         "node-fetch": "^2.3.0"
       }
     },
@@ -224,13 +212,20 @@
       }
     },
     "google-photos-album-image-url-fetch": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/google-photos-album-image-url-fetch/-/google-photos-album-image-url-fetch-1.3.0.tgz",
-      "integrity": "sha512-mEJb83ug70fe6zsr3x7gLUyp9Btq2h9XvGeSglKglbbZpUXuBSduao2MXAaX+tRroXjNiXRG0KyHO1Lcpc6Mbw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/google-photos-album-image-url-fetch/-/google-photos-album-image-url-fetch-2.1.0.tgz",
+      "integrity": "sha512-vncgSQA75KKCMmB1N3g7GlhI9rnC6vfgKPxnZfjmNbHqhT139Q/FR8nstAJ+tulUCImYuv1vrQEydzzU7wqdNA==",
       "requires": {
         "abort-controller": "^3.0.0",
-        "fast-deep-equal": "^2.0.1",
-        "gaxios": "^2.0.1"
+        "fast-deep-equal": "^3.1.3",
+        "gaxios": "^3.0.3"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        }
       }
     },
     "har-schema": {
@@ -263,12 +258,12 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
       "requires": {
-        "agent-base": "^4.3.0",
-        "debug": "^3.1.0"
+        "agent-base": "6",
+        "debug": "4"
       }
     },
     "image-downloader": {
@@ -278,6 +273,11 @@
       "requires": {
         "request": "^2.88.0"
       }
+    },
+    "is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
     },
     "is-typedarray": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "ISC",
   "dependencies": {
     "chalk": "^2.4.2",
-    "google-photos-album-image-url-fetch": "^1.3.0",
+    "google-photos-album-image-url-fetch": "^2.1.0",
     "image-downloader": "^3.5.0",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",


### PR DESCRIPTION
To follow Google Photos's change, you should updtae `google-photos-album-image-url-fetch` to v2.1.0 (https://github.com/yumetodo/google-photos-album-image-url-fetch/pull/6).

# Changelog

## v2.1.0

- follow google photos change ( 3865e2c )
- improve documents( #4, `@loopingz` )
- update dependencies

## v2.0.1

reduce package size

## v2.0.0

GooglePhotos.Albums namespace is now removed!

no other features are changed!
